### PR TITLE
[63] Allow contributors github id to be sorted in alphabetical order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,4 +1,4 @@
-const contributors = require('./contributors.json')
+const rawContributors = require('./contributors.json')
 let stats
 if (process.env.ENV_TYPE === 'mock') {
   stats = require('./mock-stats-generator')
@@ -7,6 +7,12 @@ if (process.env.ENV_TYPE === 'mock') {
 }
 
 const findCountryCode = require('./country-codes')
+
+let contributors = {}
+//Sort contributors github id in alphabetical order
+Object.keys(rawContributors).sort().forEach(function(githubUserId) {
+  contributors[githubUserId] = rawContributors[githubUserId];
+});
 
 exports.sourceNodes = async ({
   actions,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,10 +10,9 @@ const findCountryCode = require('./country-codes')
 
 let contributors = {}
 //Sort contributors github id in alphabetical order
-Object.keys(rawContributors).sort().forEach(function(githubUserId) {
+Object.keys(rawContributors).sort().forEach((githubUserId) => {
   contributors[githubUserId] = rawContributors[githubUserId];
 });
-
 exports.sourceNodes = async ({
   actions,
   createContentDigest,


### PR DESCRIPTION
## Issue

<!-- The issue url that you are working on -->
[Add github action to automatically sort](https://github.com/subeshb1/developer-community-stats/issues/63)
## Description
Currently while adding new contributor in `contributors.json` contributors manually have to place their github user name in alphabetical order. This can be issue for new contributors. In this PR we have added functionality to automatically sort users by their GitHub account id.
<!-- Describe what changes you made in this Pull request -->

## Checklist

<!-- Feel free to add ore remove checklist according to your Pull request requirements. -->

- [ ] Github action build passing
- [ ] No merge conflicts