### PR TITLE
add hilbug to contributors.json

### DIFF
--- a/contributors.json
+++ b/contributors.json
@@ -119,6 +119,13 @@
     "linkedin": "https://www.linkedin.com/in/hasna-akbar-ali-1485981b0/",
     "name": "Hasna Akbar Ali"
   },
+  "hilbug": {
+    "country": "United States",
+    "name": "Hilary Ferraro",
+    "linkedin": "https://www.linkedin.com/in/hferraro/",
+    "twitter": "https://twitter.com/HilbugCodes",
+    "website":"https://hilbug.github.io/"
+ },
   "hinsxd": {
     "country": "Hong Kong",
     "name": "Alvin Li",


### PR DESCRIPTION
## Issue

https://github.com/subeshb1/developer-community-stats/issues/120

## Description

I added github "hilbug" to the contributors.json file.

## Checklist

- [X] Added contributor object in ascending order in `contributors.json`
- [X] No merge conflicts
