### PR TITLE
Fix color toggling for "Made with" icons

### DIFF
--- a/src/css/components/_footer.scss
+++ b/src/css/components/_footer.scss
@@ -82,7 +82,7 @@
 .madeWith .item {
   margin-left: 10px;
   margin-right: 10px;
-  color: white;
+  color: var(--theme-secondary-color);
   font-size: 1.2rem;
 }
 


### PR DESCRIPTION
## Issue

#161 

## Description

Fixes icons not showing in Light primary color toggle

## Checklist

- [x] Github action build passing
- [x] No merge conflicts
