### PR TITLE
Fixed issue #287, all nav elements show in mobile SM

### DIFF
--- a/src/css/components/_navbar.scss
+++ b/src/css/components/_navbar.scss
@@ -16,6 +16,10 @@
     font-size: 2rem;
     color: var(--theme-secondary-color);
   }
+  button.lg-navbar__item {
+    padding: 0;
+    transform: translateY(3px);
+  }
   .lg-navbar__item {
     font-size: 14px;
     user-select: none;
@@ -175,6 +179,22 @@
   }
 }
 
+@media (min-width: 310px) and (max-width: 352px) {
+  .lg-navbar {
+    padding: 10px 10px;
+    margin: 0;
+  }
+  a.lg-navbar__item {
+    padding: 0 !important;
+  }
+}
+@media (min-width: 700px) {
+  .lg-navbar {
+    button.lg-navbar__item {
+      padding: 2px 0.5em;
+    }
+  }
+}
 @media (max-width: 700px) {
   .st-navbar {
     display: flex;


### PR DESCRIPTION
## Issue

https://github.com/subeshb1/developer-community-stats/issues/287

## Description

The icon of changing the theme color, is not showing in the range 340px to 320, and vertical alignment is a bit off.
I fixed that to show up to 310px mobile device's width, otherwise we have to change the layout of the nav bar, this is a good solution in my opinion

# ScreenShots
before:
![Screenshot from 2020-10-19 10-28-57](https://user-images.githubusercontent.com/20237313/96430546-32fefd00-11fa-11eb-9f64-e6a700771e48.png)
after:
![Screenshot from 2020-10-19 10-29-32](https://user-images.githubusercontent.com/20237313/96430567-3b573800-11fa-11eb-9827-c5ed650d2284.png)

